### PR TITLE
feat: add --version CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ python main.py --path /path/to/repo
 
 # Adjust refresh rate (default: 2.0 seconds)
 python main.py --refresh 3.0
+
+# Show version
+python main.py --version
 ```
 
 ## Features

--- a/config.py
+++ b/config.py
@@ -28,6 +28,7 @@ COLORS = {
 # Panel title style
 PANEL_TITLE_STYLE = "bold bright_white"
 
+VERSION = "1.0.0"
 
 @dataclass
 class Config:

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 from rich.live import Live
 
-from config import Config
+from config import Config, VERSION
 from git_parser import GitParser
 from ui import Dashboard, GitData
 from watcher import GitWatcher
@@ -29,6 +29,11 @@ def parse_args():
         type=float,
         default=2.0,
         help="Refresh rate in seconds (default: 2.0)"
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"GitPulse {VERSION}"
     )
     return parser.parse_args()
 


### PR DESCRIPTION
## What does this PR do?

Adds a `--version` command-line argument to GitPulse that prints the current version and exits. This includes defining a `VERSION` constant in config.py and integrating it into the argument parser in main.py.

## Which issue does it close?

Closes #1 

## How to test it

1. Checkout this branch
2. Run `pip install -r requirements.txt`
3. Run `python main.py --version`
4. Verify that it outputs GitPulse 1.0.0 and exits cleanly

## Checklist

- [x] `python main.py --version` runs without errors and prints the version
- [x] Code follows PEP 8 style guidelines
- [x] Commit message uses conventional format (e.g., `feat:`, `fix:`, `docs:`)
- [x] No unrelated changes included
- [x] Updated documentation if needed
