### PR TITLE
fix: show an error message when git is missing from PATH

### DIFF
--- a/git_parser.py
+++ b/git_parser.py
@@ -1,10 +1,16 @@
 """Git repository data parser using subprocess and gitpython."""
 from datetime import datetime, timezone
 from pathlib import Path
+import sys
 
-from git import Repo
-from git.exc import InvalidGitRepositoryError, RepositoryDirtyError
-
+try:
+    from git import Repo
+    from git.exc import InvalidGitRepositoryError, RepositoryDirtyError
+except ImportError as e:
+    if "Bad git executable" in str(e):
+        print("Error: git is not installed or not found in PATH.")
+        sys.exit(1)
+    raise
 
 class GitParser:
     """Parses git repository information."""

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from rich.live import Live
 
 from config import Config, VERSION
-from git_parser import GitParser
+import subprocess
 from ui import Dashboard, GitData
 from watcher import GitWatcher
 
@@ -38,7 +38,7 @@ def parse_args():
     return parser.parse_args()
 
 
-def build_git_data(git_parser: GitParser, repo_path: Path) -> GitData:
+def build_git_data(git_parser, repo_path: Path) -> GitData:
     """Build GitData from current repository state."""
     return GitData(
         branch=git_parser.get_current_branch(),
@@ -53,6 +53,15 @@ def build_git_data(git_parser: GitParser, repo_path: Path) -> GitData:
 
 def main():
     """Main entry point for GitPulse dashboard."""
+    # Check if git is installed
+    try:
+        subprocess.run(["git", "--version"], check=True, capture_output=True)
+    except FileNotFoundError:
+        print("Error: git is not installed or not found in PATH.")
+        sys.exit(1)
+
+    from git_parser import GitParser
+    
     args = parse_args()
     config = Config(refresh_rate=args.refresh, repo_path=args.path)
 

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from rich.live import Live
 
 from config import Config, VERSION
-import subprocess
+from git_parser import GitParser
 from ui import Dashboard, GitData
 from watcher import GitWatcher
 
@@ -38,7 +38,7 @@ def parse_args():
     return parser.parse_args()
 
 
-def build_git_data(git_parser, repo_path: Path) -> GitData:
+def build_git_data(git_parser: GitParser, repo_path: Path) -> GitData:
     """Build GitData from current repository state."""
     return GitData(
         branch=git_parser.get_current_branch(),
@@ -53,15 +53,6 @@ def build_git_data(git_parser, repo_path: Path) -> GitData:
 
 def main():
     """Main entry point for GitPulse dashboard."""
-    # Check if git is installed
-    try:
-        subprocess.run(["git", "--version"], check=True, capture_output=True)
-    except FileNotFoundError:
-        print("Error: git is not installed or not found in PATH.")
-        sys.exit(1)
-
-    from git_parser import GitParser
-    
     args = parse_args()
     config = Config(refresh_rate=args.refresh, repo_path=args.path)
 


### PR DESCRIPTION
## What does this PR do?

Adds a check for the `git` executable before creating `GitParser`. If `git` is not installed or not available in PATH, the app now shows an error message and exits cleanly instead of crashing with a traceback.

## Which issue does it close?

Closes #10

## How to test it

1. Checkout this branch
2. Run `pip install -r requirements.txt`
3. Run `python main.py`
4. Verify that the app starts normally when `git` is available
5. Temporarily remove `git` from PATH and run `python main.py`
6. Verify that it prints:
   `Error: git is not installed or not found in PATH.`

## Checklist

- [x] `python main.py` runs without errors
- [x] Code follows PEP 8 style guidelines
- [x] Commit message uses conventional format
- [x] No unrelated changes included
- [ ] Updated documentation if needed