### PR TITLE
fix: replace bare except in get_today_changes

### DIFF
--- a/git_parser.py
+++ b/git_parser.py
@@ -132,7 +132,7 @@ class GitParser:
                                 removed = len([l for l in diff_text.split('\n') if l.startswith('-') and not l.startswith('---')])
                                 files[path]["added"] += added
                                 files[path]["removed"] += removed
-                        except:
+                        except Exception:
                             pass
                 else:
                     # Initial commit - list files


### PR DESCRIPTION
## What does this PR do?

Replaces a bare exception handler in `get_today_changes()` with `except Exception:` so `KeyboardInterrupt` and `SystemExit` are not swallowed.

## Which issue does it close?

Closes #8

## How to test it

1. Checkout this branch
2. Run `pip install -r requirements.txt`
3. Run `python -m py_compile main.py git_parser.py ui.py config.py watcher.py`
4. Run `python main.py --version`
5. Verify that it prints `GitPulse 1.0.0`

## Checklist

- [x] `python main.py` runs without errors
- [x] Code follows PEP 8 style guidelines
- [x] Commit message uses conventional format (e.g., `feat:`, `fix:`, `docs:`)
- [x] No unrelated changes included
- [x] Updated documentation if needed